### PR TITLE
fix: activate lazy quota windows through the Responses endpoint

### DIFF
--- a/probe.go
+++ b/probe.go
@@ -8,9 +8,9 @@ import (
 const (
 	resetProbeAfterResetDelay = 10 * time.Minute
 	resetProbeCloseThreshold  = 3 * time.Minute
-	codexResetProbeEndpoint   = "https://chatgpt.com/backend-api/codex/responses/compact"
+	codexResetProbeEndpoint   = "https://chatgpt.com/backend-api/codex/responses"
 	codexResetProbeModel      = "gpt-5.4-mini"
-	resetProbePayload         = `{"model":"gpt-5.4-mini","instructions":"","input":[{"type":"message","role":"user","content":[{"type":"input_text","text":"ping"}]}]}`
+	resetProbePayload         = `{"model":"gpt-5.4-mini","instructions":"","input":[{"type":"message","role":"user","content":[{"type":"input_text","text":"ping"}]}],"stream":true,"store":false}`
 )
 
 func probeWindowDuration(window QuotaWindow) (time.Duration, bool) {

--- a/probe_runtime.go
+++ b/probe_runtime.go
@@ -18,6 +18,15 @@ type probeReadResult struct {
 	Quota       ParsedQuota
 	Credentials CodexCredentials
 }
+type probeActivationStatusError struct {
+	status int
+	body   []byte
+}
+
+func (e probeActivationStatusError) Error() string {
+	return fmt.Sprintf("probe activation request returned status %d: response body: %s", e.status, sanitizedBodySummary(e.body))
+}
+
 type probeSequencePayload struct {
 	Binding  RuntimeBinding
 	Windows  []ProbeWindowKind
@@ -974,6 +983,7 @@ func (r *QuotaRefresher) runTypedHeld(ctx context.Context, intent Intent, held *
 	case OperationProbeSequence:
 		p := intent.Payload.(probeSequencePayload)
 		attempt := p.Attempt
+		stage := "probe_start"
 		fields := func(windows []ProbeWindowKind) map[string]any {
 			return map[string]any{"auth_id": intent.AuthID, "attempt_id": attempt.AttemptID, "windows": append([]ProbeWindowKind(nil), windows...)}
 		}
@@ -1004,12 +1014,20 @@ func (r *QuotaRefresher) runTypedHeld(ctx context.Context, intent Intent, held *
 			failureFields := fields(windows)
 			failureFields["error"] = "probe_operation_failed"
 			failureFields["error_category"] = "external_callback"
+			failureFields["stage"] = stage
+			var activationStatus probeActivationStatusError
 			var status quotaStatusError
 			switch {
+			case errors.As(err, &activationStatus):
+				failureFields["error"] = "activation_http_status"
+				failureFields["error_category"] = "upstream_http"
+				failureFields["http_status"] = activationStatus.status
+				failureFields["response_summary"] = sanitizedProbeResponseSummary(activationStatus.body)
 			case errors.As(err, &status):
 				failureFields["error"] = "quota_http_status"
 				failureFields["error_category"] = "upstream_http"
 				failureFields["http_status"] = status.status
+				failureFields["response_summary"] = sanitizedProbeResponseSummary(status.body)
 			case errors.Is(err, ErrCapabilityB):
 				failureFields["error"] = "background_not_authorized"
 				failureFields["error_category"] = "authorization"
@@ -1062,6 +1080,7 @@ func (r *QuotaRefresher) runTypedHeld(ctx context.Context, intent Intent, held *
 			return OperationResult{Token: intent.Token, Err: err}
 		}
 		if p.Recovery {
+			stage = "recovery_verify_quota"
 			if attempt.SendFenceSeq == 0 {
 				attempt.SendFenceSeq = intent.StartedAfter
 			}
@@ -1079,6 +1098,7 @@ func (r *QuotaRefresher) runTypedHeld(ctx context.Context, intent Intent, held *
 			if err != nil {
 				return fail(err, true)
 			}
+			stage = "persist_recovery_verification"
 			if err = r.persistVerifiedProbeCompletion(intent.Instance, attempt.AttemptID, vr.Quota, ProbeAttemptSending, ProbeAttemptSent, ProbeAttemptSentUnknown); err != nil {
 				recordFailure(err, true, p.Windows)
 				return OperationResult{Token: intent.Token, Err: err}
@@ -1089,6 +1109,7 @@ func (r *QuotaRefresher) runTypedHeld(ctx context.Context, intent Intent, held *
 			return res
 		}
 		recordLog("info", "probe.precheck_started", "开始检查疑似未激活的额度周期", fields(p.Windows))
+		stage = "precheck_quota"
 		_, err := r.probeFence.Next() // actual-start precheck sequence, distinct from completedFence
 		if err != nil {
 			return fail(err, false)
@@ -1126,10 +1147,12 @@ func (r *QuotaRefresher) runTypedHeld(ctx context.Context, intent Intent, held *
 		attempt.CreatedAt = r.now()
 		attempt.VerifyNotBefore = attempt.CreatedAt.Add(3 * time.Second)
 		attempt.SuppressUntil = attempt.CreatedAt.Add(10 * time.Minute)
+		stage = "persist_activation_prepared"
 		if err = r.probeWAL.PersistSending(attempt); err != nil {
 			return fail(err, false)
 		}
 		held.MarkProbeSent(attempt.SuppressUntil)
+		stage = "activation_post"
 		err = held.DoHTTP(ctx, func(context.Context) error {
 			return r.probeWAL.ExecuteSend(func() error {
 				resp, e := r.doBackgroundHTTPRequest(pluginapi.HTTPRequest{Method: http.MethodPost, URL: codexResetProbeEndpoint, Headers: http.Header{"Authorization": []string{"Bearer " + pre.Credentials.AccessToken}, "Chatgpt-Account-Id": []string{pre.Credentials.ChatGPTAccountID}, "Content-Type": []string{"application/json"}}, Body: resetProbePayloadBytes()}, true)
@@ -1137,7 +1160,7 @@ func (r *QuotaRefresher) runTypedHeld(ctx context.Context, intent Intent, held *
 					return e
 				}
 				if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-					return quotaStatusError{status: resp.StatusCode, body: resp.Body}
+					return probeActivationStatusError{status: resp.StatusCode, body: resp.Body}
 				}
 				return nil
 			})
@@ -1145,10 +1168,12 @@ func (r *QuotaRefresher) runTypedHeld(ctx context.Context, intent Intent, held *
 		if err != nil {
 			return fail(err, true)
 		}
+		stage = "persist_activation_sent"
 		if err = r.probeWAL.PersistSent(intent.Instance, attempt.AttemptID, r.now()); err != nil {
 			return fail(err, true)
 		}
 		recordLog("info", "probe.activation_sent", "已发送极小请求以激活额度周期", fields(lazy))
+		stage = "propagation_wait"
 		if err = held.WaitPropagation(ctx, 3*time.Second); err != nil {
 			return fail(err, true)
 		}
@@ -1159,6 +1184,7 @@ func (r *QuotaRefresher) runTypedHeld(ctx context.Context, intent Intent, held *
 		if seq <= fence {
 			return fail(errors.New("verify read did not start after send fence"), true)
 		}
+		stage = "verify_quota"
 		vr, err := read()
 		if err != nil {
 			return fail(err, true)
@@ -1171,6 +1197,7 @@ func (r *QuotaRefresher) runTypedHeld(ctx context.Context, intent Intent, held *
 				r.probeController.SetWindow(intent.Instance, k, w)
 			}
 		}
+		stage = "persist_verification"
 		err = r.persistTerminalProbeCompletionLocked(intent.Instance, attempt.AttemptID, vr.Quota, ProbeAttemptSent)
 		r.probeHoldMu.Unlock()
 		if err != nil {

--- a/probe_runtime_test.go
+++ b/probe_runtime_test.go
@@ -30,6 +30,8 @@ type sequenceProbeHost struct {
 	urls          []string
 	requests      []pluginapi.HTTPRequest
 	quotaStatus   int
+	probeStatus   int
+	probeBody     []byte
 	getErr        error
 	doErrors      map[string][]error
 	gets          int
@@ -273,7 +275,15 @@ func (h *sequenceProbeHost) Do(req pluginapi.HTTPRequest) (pluginapi.HTTPRespons
 	}
 	var response pluginapi.HTTPResponse
 	if req.URL == codexResetProbeEndpoint {
-		response = pluginapi.HTTPResponse{StatusCode: http.StatusOK, Body: []byte(`{"usage":{"total_tokens":1}}`)}
+		status := h.probeStatus
+		if status == 0 {
+			status = http.StatusOK
+		}
+		body := h.probeBody
+		if len(body) == 0 {
+			body = []byte(`{"usage":{"total_tokens":1}}`)
+		}
+		response = pluginapi.HTTPResponse{StatusCode: status, Body: body}
 	} else if req.URL == resetCreditsEndpoint {
 		response = pluginapi.HTTPResponse{StatusCode: http.StatusOK, Body: []byte(`{}`)}
 	} else {
@@ -1552,6 +1562,100 @@ func TestProbeFailureLogRedactsSecrets(t *testing.T) {
 		if strings.Contains(errText, forbidden) {
 			t.Fatalf("probe failure log leaked %q: %#v", forbidden, failures[0])
 		}
+	}
+}
+
+func TestProbeActivationHTTPFailureLogsStageAndSanitizedResponse(t *testing.T) {
+	now := time.Date(2026, 7, 18, 22, 59, 55, 0, time.UTC)
+	r, host, _ := newFirstObservedWeeklyLazyRuntime(t, now)
+	host.mu.Lock()
+	host.probeStatus = http.StatusNotFound
+	host.probeBody = []byte(`{"detail":"model not found","access_token":"access-token-sentinel"}`)
+	host.mu.Unlock()
+
+	if err := r.RunProbeDueOnce(context.Background()); err == nil {
+		t.Fatal("RunProbeDueOnce returned nil error")
+	}
+	logs := r.state.Snapshot(now).Logs
+	var failure *LogEntry
+	for i := range logs {
+		if logs[i].Event == "probe.failed" {
+			failure = &logs[i]
+			break
+		}
+	}
+	if failure == nil {
+		t.Fatalf("logs = %#v, want probe.failed", logs)
+	}
+	if got := failure.Fields["error"]; got != "activation_http_status" {
+		t.Fatalf("error = %#v, want activation_http_status", got)
+	}
+	if got := failure.Fields["stage"]; got != "activation_post" {
+		t.Fatalf("stage = %#v, want activation_post", got)
+	}
+	if got := failure.Fields["http_status"]; got != http.StatusNotFound {
+		t.Fatalf("http_status = %#v, want 404", got)
+	}
+	if got := failure.Fields["sent"]; got != true {
+		t.Fatalf("sent = %#v, want true", got)
+	}
+	summary, _ := failure.Fields["response_summary"].(string)
+	if !strings.Contains(summary, "model not found") || strings.Contains(summary, "access-token-sentinel") {
+		t.Fatalf("response_summary = %q, want useful redacted detail", summary)
+	}
+	for _, entry := range logs {
+		if entry.Event == "probe.activation_sent" {
+			t.Fatalf("activation_sent logged after rejected POST: %#v", logs)
+		}
+	}
+}
+
+func TestProbeActivationRequestUsesMinimalResponsesChanges(t *testing.T) {
+	now := time.Date(2026, 7, 18, 22, 59, 55, 0, time.UTC)
+	r, host, _ := newFirstObservedWeeklyLazyRuntime(t, now)
+
+	if err := r.RunProbeDueOnce(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	host.mu.Lock()
+	defer host.mu.Unlock()
+	var activation *pluginapi.HTTPRequest
+	for i := range host.requests {
+		if host.requests[i].Method == http.MethodPost && host.requests[i].URL == codexResetProbeEndpoint {
+			request := host.requests[i]
+			activation = &request
+			break
+		}
+	}
+	if activation == nil {
+		t.Fatalf("requests = %#v, want activation POST", host.requests)
+	}
+	want := map[string]string{
+		"Authorization":      "Bearer access",
+		"Chatgpt-Account-Id": "acct",
+		"Content-Type":       "application/json",
+	}
+	if len(activation.Headers) != len(want) {
+		t.Errorf("activation headers = %#v, want only original three headers", activation.Headers)
+	}
+	for name, value := range want {
+		if got := activation.Headers.Get(name); got != value {
+			t.Errorf("%s = %q, want %q", name, got, value)
+		}
+	}
+	var body struct {
+		Model  string `json:"model"`
+		Stream bool   `json:"stream"`
+		Store  bool   `json:"store"`
+	}
+	if err := json.Unmarshal(activation.Body, &body); err != nil {
+		t.Fatalf("activation body: %v", err)
+	}
+	if body.Model != codexResetProbeModel || !body.Stream || body.Store {
+		t.Fatalf("activation body = %#v, want model=%q stream=true store=false", body, codexResetProbeModel)
+	}
+	if string(activation.Body) != resetProbePayload {
+		t.Fatalf("activation body = %s, want original payload plus stream/store only", activation.Body)
 	}
 }
 

--- a/refresh.go
+++ b/refresh.go
@@ -2228,6 +2228,65 @@ func sanitizedBodySummary(body []byte) string {
 	return summary
 }
 
+func sanitizedProbeResponseSummary(body []byte) string {
+	if len(body) == 0 {
+		return "<empty>"
+	}
+	var value any
+	if err := json.Unmarshal(body, &value); err != nil {
+		return fmt.Sprintf("<non-json response body: %d bytes>", len(body))
+	}
+	safe := probeDiagnosticValue(value)
+	if safe == nil {
+		return "<json response without diagnostic fields>"
+	}
+	encoded, err := json.Marshal(safe)
+	if err != nil {
+		return "<unavailable>"
+	}
+	summary := redactSecrets(string(encoded))
+	if len(summary) > maxErrorBodySummaryLen {
+		summary = summary[:maxErrorBodySummaryLen] + "..."
+	}
+	return summary
+}
+
+func probeDiagnosticValue(value any) any {
+	switch typed := value.(type) {
+	case map[string]any:
+		out := make(map[string]any)
+		for key, child := range typed {
+			switch strings.ToLower(key) {
+			case "error", "type", "code", "message", "detail", "title", "status", "param":
+				if sanitized := probeDiagnosticValue(child); sanitized != nil {
+					out[key] = sanitized
+				}
+			}
+		}
+		if len(out) == 0 {
+			return nil
+		}
+		return out
+	case []any:
+		out := make([]any, 0, len(typed))
+		for _, child := range typed {
+			if sanitized := probeDiagnosticValue(child); sanitized != nil {
+				out = append(out, sanitized)
+			}
+		}
+		if len(out) == 0 {
+			return nil
+		}
+		return out
+	case string:
+		return redactSecrets(typed)
+	case float64, bool, nil:
+		return typed
+	default:
+		return nil
+	}
+}
+
 func (ABIHostClient) ListAuths() ([]pluginapi.HostAuthFileEntry, error) {
 	result, err := callHostCallback(pluginabi.MethodHostAuthList, map[string]any{})
 	if err != nil {


### PR DESCRIPTION
## Summary

- send reset probes to `/backend-api/codex/responses` instead of the unavailable `/responses/compact` route
- add the two fields required by the Responses endpoint: `stream: true` and `store: false`
- retain the existing `gpt-5.4-mini` model, `ping` input, and original three request headers
- distinguish activation POST failures from quota-read failures
- record the exact Probe stage and a strictly allowlisted, redacted response summary
- add regression coverage for the minimal request and diagnostic redaction

## Background

The compact endpoint returned `404 {"detail":"Not Found"}` for Codex accounts, so lazy quota windows never activated and their reset timestamps kept rolling forward. The minimal Responses request was verified with HTTP 200 and a completed response while consuming 12 tokens.

## Testing

- `go test ./...`
- `go vet ./...`
- verified the minimal upstream request returns HTTP 200 and `response.completed`
