### PR TITLE
fix: use English plugin sidebar label

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,9 @@ The page provides:
 - quota refresh, log viewing/export, and configuration import/export; and
 - English and Chinese interface switching.
 
+The CPA plugin menu API accepts only one static label, so the registered
+sidebar name is **Codex Scheduler** in every management UI language.
+
 Protected data and actions require the CPA Management key. The key remains only
 in the current browser page session and is not saved to plugin state,
 `localStorage`, `sessionStorage`, exports, or logs.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -225,7 +225,7 @@ log_retention: 24h
 
 ## 管理界面
 
-从 CPA Management Center 打开 **Codex 调度器**，或者访问：
+从 CPA Management Center 打开 **Codex Scheduler**，或者访问：
 
 ```text
 /v0/resource/plugins/codex-quota-scheduler/status
@@ -240,6 +240,9 @@ log_retention: 24h
 - 别名、备注、标签、分组和单账号插件优先级编辑；
 - 额度刷新、日志查看/导出以及配置导入/导出；
 - 中英文界面切换。
+
+CPA 插件菜单 API 只能注册一个静态名称，因此所有管理界面的侧边栏统一显示
+**Codex Scheduler**。
 
 受保护的数据和操作需要 CPA 管理密钥。密钥只保留在当前浏览器页面会话中，
 不会写入插件状态、`localStorage`、`sessionStorage`、导出文件或日志。

--- a/management.go
+++ b/management.go
@@ -179,7 +179,7 @@ func RegisterManagement() pluginapi.ManagementRegistrationResponse {
 		Resources: []pluginapi.ResourceRoute{
 			{
 				Path:        "/status",
-				Menu:        "Codex 调度器",
+				Menu:        "Codex Scheduler",
 				Description: "Open scheduler quota status.",
 			},
 		},

--- a/management_test.go
+++ b/management_test.go
@@ -27,6 +27,9 @@ func TestManagementRegisterExposesStatusResourceAndRoutes(t *testing.T) {
 	if resources["/status"].Menu == "" {
 		t.Fatalf("status resource Menu is empty: %#v", resources["/status"])
 	}
+	if resources["/status"].Menu != "Codex Scheduler" {
+		t.Fatalf("status resource Menu = %q, want English static label", resources["/status"].Menu)
+	}
 	if _, ok := resources["/status-data"]; ok {
 		t.Fatalf("status-data resource is still registered: %#v", resp.Resources)
 	}


### PR DESCRIPTION
## Summary

- register the static CPA plugin menu label as `Codex Scheduler`
- document why the same sidebar label is used for every CPA language
- add a focused registration test for the menu label

CPA currently exposes one static `ResourceRoute.Menu` string and no localized menu API, so a single English product name avoids showing a Chinese-only label in English CPA installations.

This PR is independent from the management-page localization changes in #8.

## Validation

- `go test ./...`
- `go vet ./...`